### PR TITLE
Fix runclient for macos (-XstartOnFirstThread)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 buildscript {
     repositories {
         mavenLocal()
@@ -71,6 +73,9 @@ task runclient(type: JavaExec) {
     group = "MCP"
     description = "Runs the client"
     classpath sourceSets.main.runtimeClasspath
+    if (Os.isFamily(Os.FAMILY_MAC)) {
+        jvmArgs '-XstartOnFirstThread'
+    }
     args '--gameDir', '.'
     args '--version', minecraft_version
     args '--assetsDir', downloadAssets.output


### PR DESCRIPTION
This pull fixes this error on macos:
`Caused by: java.lang.IllegalStateException: GLFW windows may only be created on the main thread and that thread must be the first thread in the process. Please run the JVM with -XstartOnFirstThread. For offscreen rendering, make sure another window toolkit (e.g. AWT or JavaFX) is initialized before GLFW.`