### PR TITLE
Add Gradle Wrapper validation workflow

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Adds a workflow for running the official Gradle Wrapper Validation Action to make sure the Gradle Wrapper JAR is legit. This can be especially useful when pull requests want to upgrade the Gradle Wrapper JAR.
See https://github.com/gradle/wrapper-validation-action

Also slightly unrelated, but is there a reason why GitHub issues are disabled for this repository?